### PR TITLE
Use msg.method instead of topic

### DIFF
--- a/nodes/ccu-rpc.js
+++ b/nodes/ccu-rpc.js
@@ -30,7 +30,7 @@ module.exports = function (RED) {
                     params = [];
                 }
 
-                const method = config.method || msg.topic;
+                const method = config.method || msg.method;
 
                 if (method === 'setValue') {
                     const [address, param, value] = params;


### PR DESCRIPTION
Gibts nen Grund warum du Topic gewählt hast?
`msg.method` wäre für mich logischer. 
Topic würde ich erwarten, dass ich dann komplett `${CCU}/${Interface}/${Method}` setzen kann.